### PR TITLE
Show more information about who did what and when

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,28 @@ wfLoadExtension('ActivityLog');
 
 ## Usage
 
-Configure new hooks by adding them to the `$wgActivityLogHooksToWatch` array in
-LocalSettings.php.
+`$wgActivityLogHooksToWatch` is an associative array that configures how
+ActivityLog will log [MediaWiki events](https://www.mediawiki.org/wiki/Manual:Hooks). 
 
 ``` php
+$wgActivityLogHooksToWatch['ArticleViewHeader'] = true;
+// output: 22:55, 1 July 2020 ArticleViewHeader
+
+...
+
+$wgActivityLogHooksToWatch['ArticleViewHeader'] = 'example string'
+// output: 22:56, 1 July 2020 example string
+
+// callback is invoked with hook arguments ($article, $outputDone, $pcache in this case)
 $wgActivityLogHooksToWatch['ArticleViewHeader'] = function ($article) {
-    return 'Visited article "' . $article->getTitle() . '"';
+    // callback returns an array with the user (User), action (string), target (Title), and an 
+    // optional comment (string)
+    return array($article->getContext()->getUser(), 'visited', $article->getTitle());
 };
+// output: 22:51, 1 July 2020 (link to user) (talk|contribs) visited (link to page)
+
 ```
 
-`$wgActivityLogHooksToWatch` takes booleans, strings, and anonymous functions. A
-`true` value will log the hook name, A string will log the string itself, and a
-callback will be invoked with all the arguments that are passed by the hook.
 
 [https://www.mediawiki.org/wiki/Manual:Hooks](https://www.mediawiki.org/wiki/Manual:Hooks)
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,26 @@ $wgActivityLogHooksToWatch['ArticleViewHeader'] = 'example string'
 
 // callback is invoked with hook arguments ($article, $outputDone, $pcache in this case)
 $wgActivityLogHooksToWatch['ArticleViewHeader'] = function ($article) {
-    // callback returns an array with the user (User), action (string), target (Title), and an 
-    // optional comment (string)
-    return array($article->getContext()->getUser(), 'visited', $article->getTitle());
+    // callback returns an array with the user (User), target (Title), a messageKey (String), 
+    // following any additional parameters you might want that you can reference in the message
+    return array($article->getContext()->getUser(), $article->getTitle(), $messageKey,
+        $_SERVER['HTTP_REFERER']);
 };
 // output: 22:51, 1 July 2020 (link to user) (talk|contribs) visited (link to page)
 
 ```
 
+For the `$messageKey` above, you'll need to include your own i18n file and let MediaWiki
+know about it.  This can be done in the LocalSettings with something like:
 
+```
+$wgMessagesDirs['ActivityLogConfiguration'] = 'ActivityLogConfiguration/i18n';
+```
+
+You can read more about what those pages look like
+[on the MediaWiki Localisation page](https://www.mediawiki.org/wiki/Localisation).
+
+A listing of all the hooks can be found at:
 [https://www.mediawiki.org/wiki/Manual:Hooks](https://www.mediawiki.org/wiki/Manual:Hooks)
 
 ## Internationalization

--- a/README.md
+++ b/README.md
@@ -8,30 +8,26 @@ at `Special:Log`.
 
 * Download and place the file(s) in a directory called ActivityLog in your extensions/ folder
 * Add the following line to your LocalSettings.php
-```
+```php
 wfLoadExtension('ActivityLog');
 ```
 
 ## Usage
 
-Enable through adding to the `$wgActivityLogHooksToWatch` global variable,
-then viewing through the Special:Log page.
+Configure new hooks by adding them to the `$wgActivityLogHooksToWatch` array in
+LocalSettings.php.
 
-The page title, hook name, and user are logged to the main Log page.
-
-## Parameters
-
-* `$wgActivityLogHooksToWatch` - The hooks to watch
-
-Update by setting the key in the associative array to true, for any hook.
-For example, you can log user logins via:
-
-```php
-$wgActivityLogHooksToWatch["UserLoginComplete"]
+``` php
+$wgActivityLogHooksToWatch['ArticleViewHeader'] = function ($article) {
+    return 'Visited article "' . $article->getTitle() . '"';
+};
 ```
 
-All the normal arguments that would be passed to those hook executions are
-discarded.
+`$wgActivityLogHooksToWatch` takes booleans, strings, and anonymous functions. A
+`true` value will log the hook name, A string will log the string itself, and a
+callback will be invoked with all the arguments that are passed by the hook.
+
+[https://www.mediawiki.org/wiki/Manual:Hooks](https://www.mediawiki.org/wiki/Manual:Hooks)
 
 ## Internationalization
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Extension:ActivityLog
 
 The ActivityLog extension allows system administrators to set up logging for
-arbitrary hooks.  These log messages are currently sent to the main Log page 
+arbitrary hooks.  These log messages are currently sent to the main Log page
 at `Special:Log`.
 
 ## Installation
@@ -15,7 +15,7 @@ wfLoadExtension('ActivityLog');
 ## Usage
 
 `$wgActivityLogHooksToWatch` is an associative array that configures how
-ActivityLog will log [MediaWiki events](https://www.mediawiki.org/wiki/Manual:Hooks). 
+ActivityLog will log [MediaWiki events](https://www.mediawiki.org/wiki/Manual:Hooks).
 
 ``` php
 $wgActivityLogHooksToWatch['ArticleViewHeader'] = true;
@@ -28,7 +28,7 @@ $wgActivityLogHooksToWatch['ArticleViewHeader'] = 'example string'
 
 // callback is invoked with hook arguments ($article, $outputDone, $pcache in this case)
 $wgActivityLogHooksToWatch['ArticleViewHeader'] = function ($article) {
-    // callback returns an array with the user (User), target (Title), a messageKey (String), 
+    // callback returns an array with the user (User), target (Title), a messageKey (String),
     // following any additional parameters you might want that you can reference in the message
     return array($article->getContext()->getUser(), $article->getTitle(), $messageKey,
         $_SERVER['HTTP_REFERER']);

--- a/extension.json
+++ b/extension.json
@@ -9,7 +9,11 @@
 	"descriptionmsg": "activitylog-desc",
 	"type": "other",
 	"LogActions": {
-		"activitylog/activity": "activitylog-activity"
+		"activitylog/activity": "activitylog-activity",
+		"activitylog/simpleactivity": "activitylog-simpleactivity"
+	},
+	"LogActionsHandlers": {
+		"activitylog/*": "LogFormatter"
 	},
 	"LogHeaders": {
 		"activitylog": "activitylogpagetext"

--- a/extension.json
+++ b/extension.json
@@ -8,12 +8,11 @@
 	"url": "https://github.com/OpenTechStrategies/torque",
 	"descriptionmsg": "activitylog-desc",
 	"type": "other",
-	"LogActions": {
-		"activitylog/activity": "activitylog-activity",
-		"activitylog/simpleactivity": "activitylog-simpleactivity"
-	},
+  "LogActions": {
+    "activitylog/activity": "activitylog-activity"
+  },
 	"LogActionsHandlers": {
-		"activitylog/*": "LogFormatter"
+		"activitylog/*": "ActivityLogFormatter"
 	},
 	"LogHeaders": {
 		"activitylog": "activitylogpagetext"
@@ -30,7 +29,8 @@
 		]
 	},
 	"AutoloadClasses": {
-		"ActivityLogHooks": "include/hooks/ActivityLogHooks.php"
+		"ActivityLogHooks": "include/hooks/ActivityLogHooks.php",
+		"ActivityLogFormatter": "include/ActivityLogFormatter.php"
 	},
 	"Hooks": {
     "BeforeInitialize": "ActivityLogHooks::onBeforeInitialize"

--- a/extension.json
+++ b/extension.json
@@ -1,40 +1,40 @@
 {
-	"name": "ActivityLog",
-	"version": "0.0.1",
-	"author": [
+  "name": "ActivityLog",
+  "version": "0.0.1",
+  "author": [
     "Open Tech Strategies"
-	],
+  ],
   "license-name": "GPL-2.0-or-later",
-	"url": "https://github.com/OpenTechStrategies/torque",
-	"descriptionmsg": "activitylog-desc",
-	"type": "other",
+  "url": "https://github.com/OpenTechStrategies/torque",
+  "descriptionmsg": "activitylog-desc",
+  "type": "other",
   "LogActions": {
     "activitylog/activity": "activitylog-activity"
   },
-	"LogActionsHandlers": {
-		"activitylog/*": "ActivityLogFormatter"
-	},
-	"LogHeaders": {
-		"activitylog": "activitylogpagetext"
-	},
-	"LogNames": {
-		"activitylog": "activitylogpage"
-	},
-	"LogTypes": [
-		"activitylog"
-	],
-	"MessagesDirs": {
-		"ActivityLog": [
-			"i18n"
-		]
-	},
-	"AutoloadClasses": {
-		"ActivityLogHooks": "include/hooks/ActivityLogHooks.php",
-		"ActivityLogFormatter": "include/ActivityLogFormatter.php"
-	},
-	"Hooks": {
+  "LogActionsHandlers": {
+    "activitylog/*": "ActivityLogFormatter"
+  },
+  "LogHeaders": {
+    "activitylog": "activitylogpagetext"
+  },
+  "LogNames": {
+    "activitylog": "activitylogpage"
+  },
+  "LogTypes": [
+    "activitylog"
+  ],
+  "MessagesDirs": {
+    "ActivityLog": [
+      "i18n"
+    ]
+  },
+  "AutoloadClasses": {
+    "ActivityLogHooks": "include/hooks/ActivityLogHooks.php",
+    "ActivityLogFormatter": "include/ActivityLogFormatter.php"
+  },
+  "Hooks": {
     "BeforeInitialize": "ActivityLogHooks::onBeforeInitialize"
-	},
+  },
   "Config": {
     "ActivityLogHooksToWatch": []
   }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,12 +1,12 @@
 {
-	"@metadata": {
-		"authors": [
+  "@metadata": {
+    "authors": [
       "Open Tech Strategies"
     ]
-	},
+  },
   "activitylog-desc": "Extension to add arbitrary hooks as log messages to Special:Log",
-	"activitylogpage": "Activity log",
-	"activitylogpagetext": "A log of acitivity specified by hooks.",
+  "activitylogpage": "Activity log",
+  "activitylogpagetext": "A log of acitivity specified by hooks.",
   "logentry-activitylog-activity": "$1 performed an Activity",
   "logentry-activitylog-simpleactivity": "$1 performed activity $4"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,6 +7,6 @@
   "activitylog-desc": "Extension to add arbitrary hooks as log messages to Special:Log",
 	"activitylogpage": "Activity log",
 	"activitylogpagetext": "A log of acitivity specified by hooks.",
-	"logentry-activitylog-activity": "$1$4$3",
-	"logentry-activitylog-simpleactivity": "$4"
+  "logentry-activitylog-activity": "$1 performed an Activity",
+  "logentry-activitylog-simpleactivity": "$1 performed activity $4"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,5 +7,6 @@
   "activitylog-desc": "Extension to add arbitrary hooks as log messages to Special:Log",
 	"activitylogpage": "Activity log",
 	"activitylogpagetext": "A log of acitivity specified by hooks.",
-	"activitylog-activity": "performed an Activity"
+	"logentry-activitylog-activity": "$1$4$3",
+	"logentry-activitylog-simpleactivity": "$4"
 }

--- a/include/ActivityLogFormatter.php
+++ b/include/ActivityLogFormatter.php
@@ -1,0 +1,21 @@
+<?php
+  
+class ActivityLogFormatter extends LogFormatter {
+
+  protected function getActionMessage() {
+    $params = $this->getMessageParameters();
+
+    if('simpleactivity' == $this->entry->getSubType() || !isset($params[3]) || !is_string($params[3])) {
+      return parent::getActionMessage();
+    }
+    $msg = $this->msg($params[3]);
+
+    if(!$msg->exists()) {
+      return parent::getActionMessage();
+    }
+    $msg->params($params);
+    return $msg;
+  }
+}
+
+?>

--- a/include/ActivityLogFormatter.php
+++ b/include/ActivityLogFormatter.php
@@ -1,5 +1,5 @@
 <?php
-  
+
 class ActivityLogFormatter extends LogFormatter {
 
   protected function getActionMessage() {

--- a/include/hooks/ActivityLogHooks.php
+++ b/include/hooks/ActivityLogHooks.php
@@ -12,9 +12,20 @@ class ActivityLogExecutor {
   public function execute(...$args) {
     global $wgTitle;
     $log = new LogPage('activitylog', false);
-    $log->addEntry('activity', $wgTitle, $this->hookName);
 
-    return $this->returnObject;
+    if (is_bool($this->returnObject)) {
+      $comment = $this->hookName;
+    } elseif (is_string($this->returnObject)) {
+      $comment = $this->returnObject;
+    } elseif (is_callable($this->returnObject)) {
+      $comment = call_user_func($this->returnObject, ...$args);
+    } else {
+      throw new Exception('Invalid ActivityLog hook handler.');
+    }
+
+    $log->addEntry('activity', $wgTitle, $comment);
+
+    return true;
   }
 }
 

--- a/include/hooks/ActivityLogHooks.php
+++ b/include/hooks/ActivityLogHooks.php
@@ -33,7 +33,7 @@ class ActivityLogExecutor {
       foreach($rest as $param) {
         $parameters["$idx::"] = $param;
       }
-      
+
       $entry->setParameters($parameters);
 
       $logid = $entry->insert();


### PR DESCRIPTION
Record user activity and control access to said records.

~~Closes #1~~

Issue #1 
> The log entries created by this extension should show who accessed which page when, and what they did (e.g., did they just view the page? Leave a comment (via the TeamComments plugin)? Make an actual edit to the page?

[2020-05-25 Notes](https://github.com/OpenTechStrategies/torque/wiki/Meeting-Notes#2020-05-25-12pm-ct-frankkarl-discussion-about-logs-and-devstaging-sites)
> Right now we're just setting booleans. We need to update the extension to take anonymous callbacks. Every MediaWiki hook has a set of arguments that get passed to that hook, e.g., "ViewPage" gets a user object and a page object. We would then pass those to the callback, and the callback would return a string that then gets inserted into MediaWiki's database for logged items, which then gets rendered to the Special:Log page.